### PR TITLE
feat: support test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags:
+    - '*'
+  workflow_dispatch:
+
+jobs:
+  rust:
+    name: file_test_runner-ubuntu-latest-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      CARGO_INCREMENTAL: 0
+      GH_ACTIONS: 1
+      RUST_BACKTRACE: full
+      RUSTFLAGS: -D warnings
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v1
+      - uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Format
+        run: |
+          cargo fmt --all -- --check
+          deno fmt --check
+
+      - name: Lint
+        run: |
+          cargo clippy --all-targets --all-features --release
+
+      - name: Build
+        run: cargo build --all-targets --all-features --release
+      - name: Test
+        run: cargo test --all-targets --all-features --release
+
+      - name: Publish
+        if: |
+          github.repository == 'denoland/file_test_runner' &&
+          startsWith(github.ref, 'refs/tags/')
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseKind:
+        description: 'Kind of release'
+        type: choice
+        options:
+          - patch
+          - minor
+        required: true
+
+jobs:
+  rust:
+    name: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.DENOBOT_PAT }}
+
+      - uses: denoland/setup-deno@v1
+      - uses: dsherret/rust-toolchain-file@v1
+
+      - name: Tag and release
+        env:
+          GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
+          GH_WORKFLOW_ACTOR: ${{ github.actor }}
+        run: |
+          git config user.email "denobot@users.noreply.github.com"
+          git config user.name "denobot"
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.20.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "exclude": [
+    "target"
+  ]
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.77.2"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Allows outputting test steps. This is useful for dprint which has multiple tests per file.

![image](https://github.com/denoland/file_test_runner/assets/1609021/ff47813b-3809-4d4a-8c36-c4903833bc35)