### PR TITLE
feat: list failures at bottom of report

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -166,6 +166,11 @@ pub fn run_tests(
       eprintln!("Test file: {}", failure.test.path.display());
       eprintln!();
     }
+    eprintln!("failures:");
+    for failure in &context.failures {
+      eprintln!("    {}", failure.test.name);
+    }
+    eprintln!();
     panic!("{} failed of {}", context.failures.len(), total_tests);
   } else {
     eprintln!("{} tests passed", total_tests);


### PR DESCRIPTION
Follow what `cargo test` does. This allows more easily copy and pasting the output for later and running only the failed tests.