### PR TITLE
feat: env var to control parallel threads

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -149,7 +149,7 @@ fn capture_backtrace() -> Option<String> {
 pub struct RunOptions {
   /// Whether to run tests in parallel. By default, this will parallelize the
   /// tests across all available threads, minus one.
-  /// 
+  ///
   /// This can be overridden by setting the `FILE_TEST_RUNNER_PARALLELISM`
   /// environment variable to the desired number of parallel threads.
   pub parallel: bool,
@@ -166,18 +166,18 @@ pub fn run_tests<TData: Clone + Send + 'static>(
   }
 
   let parallelism = if options.parallel {
-    std::env::var("FILE_TEST_RUNNER_PARALLELISM")
-      .ok()
-      .and_then(|v| v.parse().ok())
-      .unwrap_or_else(|| {
-        std::cmp::max(
-          1,
+    std::cmp::max(
+      1,
+      std::env::var("FILE_TEST_RUNNER_PARALLELISM")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| {
           std::thread::available_parallelism()
             .map(|v| v.get())
             .unwrap_or(2)
-            - 1,
-        )
-      })
+            - 1
+        }),
+    )
   } else {
     1
   };


### PR DESCRIPTION
If your tests are network bound, you can parallelize much further than CPU thread count.