### PR TITLE
fix: restore previously set local thread panic hook after running test

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -105,9 +105,9 @@ impl TestResult {
 
     let panic_message = Arc::new(Mutex::new(Vec::<u8>::new()));
 
-    LOCAL_PANIC_HOOK.with(|hook| {
+    let previous_panic_hook = LOCAL_PANIC_HOOK.with(|hook| {
       let panic_message = panic_message.clone();
-      *hook.borrow_mut() = Some(Box::new(move |info| {
+      hook.borrow_mut().replace(Box::new(move |info| {
         let backtrace = capture_backtrace();
         panic_message.lock().extend(
           format!(
@@ -119,10 +119,15 @@ impl TestResult {
           )
           .into_bytes(),
         );
-      }));
+      }))
     });
 
     let result = std::panic::catch_unwind(func);
+
+    // restore or clear the local panic hook
+    LOCAL_PANIC_HOOK.with(|hook| {
+      *hook.borrow_mut() = previous_panic_hook;
+    });
 
     // decrement the panic hook
     {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -129,7 +129,7 @@ impl TestResult {
       *hook.borrow_mut() = previous_panic_hook;
     });
 
-    // decrement the panic hook
+    // decrement the global panic hook
     {
       let mut hook_count = GLOBAL_PANIC_HOOK_COUNT.lock();
       *hook_count -= 1;


### PR DESCRIPTION
Ensures nested tests show the panic message when panicking after running a sub test.