### PR TITLE
fix: don't error for empty directories

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.82.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/collection/strategies/test_per_directory.rs
+++ b/src/collection/strategies/test_per_directory.rs
@@ -39,7 +39,9 @@ impl TestCollectionStrategy<()> for TestPerDirectoryCollectionStrategy {
       let mut tests = vec![];
 
       let mut found_dir = false;
+      let mut is_dir_empty = true;
       for entry in read_dir_entries(dir_path)? {
+        is_dir_empty = false;
         let path = entry.path();
         let file_type = entry
           .file_type()
@@ -83,7 +85,7 @@ impl TestCollectionStrategy<()> for TestPerDirectoryCollectionStrategy {
       // Error when the directory file can't be found in order to catch people
       // accidentally not naming the test file correctly
       // (ex. `__test__.json` instead of `__test__.jsonc` in Deno's case)
-      if !found_dir {
+      if !found_dir && !is_dir_empty {
         return Err(anyhow::anyhow!("Could not find '{}' in directory tree '{}'. Perhaps the file is named incorrectly?", dir_test_file_name, dir_path.display()).into());
       }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -30,7 +30,7 @@ struct Context<TData: Clone + Send + 'static> {
 
 static GLOBAL_PANIC_HOOK_COUNT: Mutex<usize> = Mutex::new(0);
 
-type PanicHook = Box<dyn Fn(&std::panic::PanicInfo) + Sync + Send>;
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo) + Sync + Send>;
 
 thread_local! {
   static LOCAL_PANIC_HOOK: RefCell<Option<PanicHook>> = RefCell::new(None);


### PR DESCRIPTION
This error is not useful for empty directories.